### PR TITLE
Move npm install from CMD to RUN instruction

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update && apt-get -y install ghostscript && apt-get clean
 
 COPY ./* ./
 
-CMD npm install && node .
+RUN npm install
+
+CMD node .
 
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The body size is currently limited to `50mb`.
 
 The docker container exposes port 80 which should be forwarded to the node service which is listening on port 3000.
 
+## Building the Docker image
+
+```docker build -t mediasuite/pdf-service .```
+
 ## Running the Docker image
 
 ```docker run -d -p 80:3000 mediasuite/pdf-service```


### PR DESCRIPTION
Avoids container running `npm install` on start.
