### PR TITLE
Dockerfile minimize layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
 FROM nodesource/trusty:LTS
+
 MAINTAINER Jonathan Prince <jonathan.prince@gmail.com>
 
+# no tty
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN sed 's/main$/main universe/' -i /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get upgrade -y
 
-# Download and install wkhtmltopdf
-RUN apt-get install -y build-essential xorg libssl-dev libxrender-dev wget gdebi
-RUN wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2/wkhtmltox-0.12.2_linux-trusty-amd64.deb
-RUN gdebi --n wkhtmltox-0.12.2_linux-trusty-amd64.deb
+# Install ghostscript, download and install wkhtmltopdf
+RUN build_deps="build-essential xorg libssl-dev libxrender-dev wget gdebi" \
+  && apt-get update \
+  && apt-get install -y --force-yes --no-install-recommends $build_deps ghostscript \
+  && wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2/wkhtmltox-0.12.2_linux-trusty-amd64.deb \
+  && gdebi --n wkhtmltox-0.12.2_linux-trusty-amd64.deb \
+  && rm -f wkhtmltox-0.12.2_linux-trusty-amd64.deb \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get purge -y --auto-remove $build_deps
 
-# install ghostscript
-RUN apt-get update && apt-get -y install ghostscript && apt-get clean
-
-COPY ./ ./
+COPY . .
 
 RUN npm install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ COPY . .
 
 RUN npm install
 
-CMD node .
+CMD ["node", "."]
 
 EXPOSE 80


### PR DESCRIPTION
Reduce number of layers in Docker image by chaining commands into a single `RUN` instruction. Reduce file size by not installing recommended packages, cleaning up wkhtmltopdf download and build dependencies.

```
REPOSITORY                       TAG                 IMAGE ID            CREATED             SIZE
mediasuite/pdf-service           latest              1e9b2c751e98        13 minutes ago      784.3 MB
mediasuite/pdf-service           previous            4eb39931239f        About an hour ago   988.4 MB
```

See [Best practices for writing Dockerfiles](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/).
