### PR TITLE
Combine apt-get update with apt-get install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,11 @@ RUN build_deps="build-essential xorg libssl-dev libxrender-dev wget gdebi" \
   && rm -rf /var/lib/apts/lists/* \
   && apt-get purge -y --auto-remove $build_deps
 
-COPY . .
+COPY package.json .
 
 RUN npm install
+
+COPY . .
 
 CMD ["node", "."]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,26 @@
 FROM nodesource/trusty:LTS
+
 MAINTAINER Jonathan Prince <jonathan.prince@gmail.com>
 
+# no tty
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN sed 's/main$/main universe/' -i /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get upgrade -y
 
-# Download and install wkhtmltopdf
-RUN apt-get install -y build-essential xorg libssl-dev libxrender-dev wget gdebi
-RUN wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb
-RUN gdebi --n wkhtmltox-0.12.2.1_linux-trusty-amd64.deb
+# Install pdftk, download and install wkhtmltopdf
+RUN build_deps="build-essential xorg libssl-dev libxrender-dev wget gdebi" \
+  && apt-get update \
+  && apt-get install -y --force-yes --no-install-recommends $build_deps pdftk \
+  && wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb \
+  && gdebi --n wkhtmltox-0.12.2.1_linux-trusty-amd64.deb \
+  && rm -f wkhtmltox-0.12.2.1_linux-trusty-amd64.deb \
+  && rm -rf /var/lib/apts/lists/* \
+  && apt-get purge -y --auto-remove $build_deps
 
-# install pdftk
-RUN sudo apt-get install pdftk --yes
-
-COPY ./ ./
+COPY . .
 
 RUN npm install
 
-CMD node .
+CMD ["node", "."]
 
 EXPOSE 80


### PR DESCRIPTION
Reduce number of layers in Docker image by combining commands into a single `RUN` instruction. Reduce file size by not installing recommended packages, cleaning up wkhtmltopdf download and build dependencies.

```
REPOSITORY                       TAG                 IMAGE ID            CREATED             SIZE
mediasuite/pdf-service           latest              0080cb51456d        28 minutes ago      831.3 MB
mediasuite/pdf-service           master              14651bf93e74        45 minutes ago      1.003 GB
```

See [Best practices for writing Dockerfiles](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/).
