### PR TITLE
Move ping get above middleware to resolve incorrect headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ const argv = require('minimist')(process.argv.slice(2))
 const bodyLimit = argv.limit || '50mb'
 const port = argv.port || 3000
 
+app.get('/ping', actions.ping)
+
 app.use(mw.setHeaders)
 app.use(bodyParser.json({limit: bodyLimit}))
 app.use(mw.setupTemp)
@@ -19,7 +21,6 @@ app.use(mw.createPdfStamp)
 app.use(mw.addStamp)
 app.use(mw.errorHandler)
 
-app.get('/ping', actions.ping)
 app.post('/', actions.sendFile)
 
 app.listen(port, () => console.log('server listening on port %d', port))


### PR DESCRIPTION
Now has correct Content-Type and no unnecessary headers.

```
$ curl -i -w "\n" http://localhost/ping
HTTP/1.1 200 OK
X-Powered-By: Express
Content-Type: text/html; charset=utf-8
Content-Length: 4
ETag: W/"4-FclJF8h5VnnstlDtdgwn8A"
Date: Mon, 22 Aug 2016 01:53:35 GMT
Connection: keep-alive

PONG
```
