### PR TITLE
allow attachments to be provided as URLs

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const tmp = require('tmp')
 const execa = require('execa')
 const debug = require('debug')('pdf-service')
+const axios = require('axios')
 
 const catchCmdlineError = (err, next) => {
   const stderr = err.stderr
@@ -23,7 +24,7 @@ module.exports = {
 
   setupTemp (req, res, next) {
     debug('setup temp storage')
-    req.temp = tmp.dirSync({unsafeCleanup: true})
+    req.temp = tmp.dirSync({ unsafeCleanup: true })
     next()
   },
 
@@ -52,23 +53,42 @@ module.exports = {
     }).catch(err => catchCmdlineError(err, next))
   },
 
-  createFileList (req, res, next) {
+  async createFileList (req, res, next) {
     debug('create file list')
     req.filelist = [`${req.temp.name}/html.pdf`]
 
-    if (req.body.attachments) {
-      // create a temp file for each pdf to attach
-      req.body.attachments.forEach((base64, i) => {
-        if (typeof base64 !== 'string') {
-          console.log(`Attachment content expected base64 string got "${typeof base64}" in payload`)
+    if (!req.body.attachments) return next()
+
+    // create a temp file for each pdf to attach
+    await Promise.all(req.body.attachments.map(async (attachment, i) => {
+      if (typeof attachment !== 'string') {
+        console.log(`Attachment content expected a string got "${typeof attachment}" in payload`)
+        return
+      }
+      if (attachment.length === 0) return
+
+      const filename = `${req.temp.name}/html.pdf${i}`
+      const regex = RegExp(/^https?:\/\//)
+      let content
+
+      if (regex.test(attachment)) {
+        try {
+          const response = await axios.get(attachment, {
+            responseType: 'arraybuffer'
+          })
+          content = response.data
+        } catch (e) {
+          console.log(e)
           return
         }
-        if (base64.length === 0) return
-        const filename = `${req.temp.name}/html.pdf${i}`
-        req.filelist.push(filename)
-        fs.writeFileSync(filename, new Buffer(base64, 'base64'))
-      })
-    }
+      } else {
+        content = Buffer.from(attachment, 'base64')
+      }
+
+      fs.writeFileSync(filename, content)
+      req.filelist.push(filename)
+    })).catch(next)
+
     next()
   },
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "wkhtmltopdf"
   ],
   "dependencies": {
+    "axios": "^0.19.0",
     "body-parser": "^1.15.0",
     "debug": "^2.2.0",
     "execa": "^0.4.0",


### PR DESCRIPTION
Attachments have been provided until now as base64 strings, this PR adds the ability to provide a URL that the service can fetch.