### PR TITLE
OPS-154 Add Docker authentication to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,13 @@
-version: 2
+version: 2.1
 
 jobs:
+
   build_docker:
     docker:
       - image: docker:18.04.0-ce
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
     working_directory: ~/pdf-service
     steps:
       - checkout
@@ -38,9 +42,12 @@ jobs:
 
 workflows:
   version: 2
+
   build_docker:
     jobs:
       - build_docker:
+          context:
+            - docker-hub-creds
           filters:
             branches:
               only:


### PR DESCRIPTION
Docker blog [Scaling Docker to Serve Millions More Developers: Network Egress](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/) announced pull rate limits to Docker subscription plans that will take effect 1 November 2020.

This PR adds Docker authentication to image pulls.

Uses CircleCI context docker-hub-creds to access environment variables.
